### PR TITLE
Mirror non-organized events to the shared calendar (organizer-aware handling)

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ from utils.logger import logger
 from utils.email_utils import send_error_email
 from utils.google_utils import build_calendar_service
 from utils.process_event import handle_event, load_processed, save_processed
+from utils.mirror import reconcile_mirrors
 from utils.health import send_health_ping
 from utils.tenacity_utils import log_before_retry, log_and_email_on_final_failure
 
@@ -233,6 +234,13 @@ def poll_calendar():
                 logger.error(f"❌ An unexpected error occurred during the poll for {cal}: {e_generic}", exc_info=True)
                 EVENTS_PROCESSED_FAILURE_TOTAL.labels(calendar_id=cal, reason='poll_level_error').inc()
                 send_error_email("Calendar Bot - UNEXPECTED Polling Error", f"Calendar: {cal}\nError: {e_generic}")
+
+        # Keep shared-calendar mirrors of non-organized events in sync: propagate
+        # source moves/cancellations and prune long-past entries.
+        try:
+            reconcile_mirrors(build_calendar_service)
+        except Exception as e_mirror:
+            logger.error(f"❌ Mirror reconciliation failed: {e_mirror}", exc_info=True)
 
         if UPTIME_KUMA_PUSH_URL:
             try:

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -1,0 +1,124 @@
+# ~/calendar_bot/tests/test_mirror.py
+import pytest
+from unittest.mock import MagicMock, patch
+
+from googleapiclient.errors import HttpError
+
+from utils import mirror
+from utils.mirror import ensure_mirror, reconcile_mirrors, is_self_organized, _snapshot, SHARED_CALENDAR_ID
+
+
+class _Resp:
+    def __init__(self, status):
+        self.status = status
+        self.reason = "error"
+
+
+def _http_error(status):
+    return HttpError(_Resp(status), b'{}')
+
+
+@pytest.fixture
+def event():
+    return {
+        'id': 'evt1',
+        'summary': 'Invited Meeting',
+        'organizer': {'email': 'boss@example.com', 'self': False},
+        'start': {'dateTime': '2030-09-05T10:00:00Z'},
+        'end': {'dateTime': '2030-09-05T11:00:00Z'},
+        'location': 'Room A',
+    }
+
+
+# --- is_self_organized ---
+
+def test_self_organized_true_when_self():
+    assert is_self_organized({'organizer': {'self': True}}) is True
+
+def test_self_organized_false_when_not_self():
+    assert is_self_organized({'organizer': {'self': False}}) is False
+
+def test_self_organized_true_when_organizer_absent():
+    # Missing organizer info -> keep existing invite behavior, don't mirror.
+    assert is_self_organized({}) is True
+
+
+# --- ensure_mirror ---
+
+def test_ensure_mirror_creates_new(event):
+    service = MagicMock()
+    service.events().insert().execute.return_value = {'id': 'mirror1'}
+    with patch.object(mirror, 'load_mirror_map', return_value={}), \
+         patch.object(mirror, 'save_mirror_map') as save:
+        assert ensure_mirror(service, 'joeltimm@gmail.com', event) is True
+    # Inserted onto the shared calendar and persisted the mapping.
+    insert_kwargs = service.events().insert.call_args.kwargs
+    assert insert_kwargs['calendarId'] == SHARED_CALENDAR_ID
+    saved_map = save.call_args.args[0]
+    assert saved_map['joeltimm@gmail.com::evt1']['mirror_id'] == 'mirror1'
+
+
+def test_ensure_mirror_skips_when_unchanged(event):
+    service = MagicMock()
+    existing = {'joeltimm@gmail.com::evt1': {'mirror_id': 'mirror1', 'snapshot': _snapshot(event)}}
+    with patch.object(mirror, 'load_mirror_map', return_value=existing), \
+         patch.object(mirror, 'save_mirror_map') as save:
+        assert ensure_mirror(service, 'joeltimm@gmail.com', event) is True
+    service.events().insert.assert_not_called()
+    service.events().patch.assert_not_called()
+    save.assert_not_called()
+
+
+def test_ensure_mirror_patches_when_changed(event):
+    service = MagicMock()
+    stale = {'joeltimm@gmail.com::evt1': {'mirror_id': 'mirror1', 'snapshot': {'summary': 'old'}}}
+    with patch.object(mirror, 'load_mirror_map', return_value=stale), \
+         patch.object(mirror, 'save_mirror_map'):
+        ensure_mirror(service, 'joeltimm@gmail.com', event)
+    patch_kwargs = service.events().patch.call_args.kwargs
+    assert patch_kwargs['calendarId'] == SHARED_CALENDAR_ID
+    assert patch_kwargs['eventId'] == 'mirror1'
+
+
+def test_ensure_mirror_skips_gracefully_without_access(event):
+    service = MagicMock()
+    service.events().insert().execute.side_effect = _http_error(403)
+    with patch.object(mirror, 'load_mirror_map', return_value={}), \
+         patch.object(mirror, 'save_mirror_map') as save:
+        assert ensure_mirror(service, 'joeltimm@gmail.com', event) is False
+    save.assert_not_called()
+
+
+# --- reconcile_mirrors ---
+
+def test_reconcile_deletes_mirror_when_source_cancelled(event):
+    service = MagicMock()
+    service.events().get().execute.return_value = {'id': 'evt1', 'status': 'cancelled'}
+    mirror_map = {'joeltimm@gmail.com::evt1': {'mirror_id': 'mirror1', 'snapshot': {}}}
+    with patch.object(mirror, 'load_mirror_map', return_value=mirror_map), \
+         patch.object(mirror, 'save_mirror_map') as save:
+        reconcile_mirrors(lambda cal: service)
+    service.events().delete.assert_called_once()
+    # Mapping entry removed.
+    assert save.call_args.args[0] == {}
+
+
+def test_reconcile_deletes_mirror_when_source_gone(event):
+    service = MagicMock()
+    service.events().get().execute.side_effect = _http_error(404)
+    mirror_map = {'joeltimm@gmail.com::evt1': {'mirror_id': 'mirror1', 'snapshot': {}}}
+    with patch.object(mirror, 'load_mirror_map', return_value=mirror_map), \
+         patch.object(mirror, 'save_mirror_map') as save:
+        reconcile_mirrors(lambda cal: service)
+    service.events().delete.assert_called_once()
+    assert save.call_args.args[0] == {}
+
+
+def test_reconcile_patches_mirror_when_source_moved(event):
+    service = MagicMock()
+    service.events().get().execute.return_value = event  # current source state
+    stale = {'joeltimm@gmail.com::evt1': {'mirror_id': 'mirror1', 'snapshot': {'summary': 'old time'}}}
+    with patch.object(mirror, 'load_mirror_map', return_value=stale), \
+         patch.object(mirror, 'save_mirror_map'):
+        reconcile_mirrors(lambda cal: service)
+    service.events().patch.assert_called_once()

--- a/tests/test_process_event.py
+++ b/tests/test_process_event.py
@@ -1,7 +1,7 @@
 # ~/calendar_bot/tests/test_process_event.py
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # Import the function we want to test
 from utils.process_event import handle_event
@@ -99,6 +99,36 @@ def test_clones_birthday_event(mock_google_service, birthday_event):
     
     mock_google_service.events().insert.assert_called_once()
     mock_google_service.events().patch.assert_not_called()
+
+@pytest.fixture
+def not_organized_event():
+    """A regular event the user was invited to but does not organize."""
+    return {
+        'id': 'invited_event_xyz',
+        'summary': "Someone Else's Meeting",
+        'eventType': 'default',
+        'organizer': {'email': 'boss@example.com', 'self': False},
+        'start': {'dateTime': '2025-09-05T10:00:00Z'},
+        'end': {'dateTime': '2025-09-05T11:00:00Z'},
+        'attendees': [{'email': 'user@example.com'}],
+    }
+
+
+def test_mirrors_non_organized_event(mock_google_service, not_organized_event):
+    mock_google_service.events().get.return_value.execute.return_value = not_organized_event
+
+    with patch('utils.process_event.ensure_mirror', return_value=True) as mock_ensure:
+        handle_event(
+            service=mock_google_service,
+            calendar_id='primary',
+            event_id='invited_event_xyz',
+            success_counter=MagicMock(),
+        )
+
+    # Should mirror, not try to add an attendee to an event it doesn't organize.
+    mock_ensure.assert_called_once()
+    mock_google_service.events().patch.assert_not_called()
+
 
 def test_duplicates_and_deletes_gmail_event(mock_google_service, from_gmail_event):
     mock_google_service.events().get.return_value.execute.return_value = from_gmail_event

--- a/utils/mirror.py
+++ b/utils/mirror.py
@@ -1,0 +1,226 @@
+# ~/calendar_bot/utils/mirror.py
+"""
+Mirror events that a source user was *invited to* (but does not organize) onto
+the shared calendar, and keep those mirrors in sync.
+
+For events the source user organizes, the bot adds the shared calendar as an
+attendee and Google propagates moves/cancellations natively. But you cannot add
+attendees to an event you don't organize, so for those we create a standalone
+"mirror" event on the shared calendar and actively reconcile it: when the source
+event moves we patch the mirror, and when the source event is cancelled/deleted
+we delete the mirror.
+
+Both source accounts have manage access to the shared calendar, so each source
+service writes (and later reconciles) its own mirrors directly — no separate
+writer account is needed. The source event -> mirror event mapping is persisted
+in MIRROR_FILE.
+"""
+import json
+import os
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+from googleapiclient.errors import HttpError
+
+from utils.logger import logger
+
+# The shared calendar we write mirrors onto (same address used for invites).
+SHARED_CALENDAR_ID = os.getenv('INVITE_EMAIL', 'joelandtaylor@gmail.com')
+MIRROR_FILE = Path(os.getenv('MIRROR_FILE', 'data/mirrored_events.json'))
+# Stop tracking (and reconciling) mirrors once the source event ended this long
+# ago. The mirror is left in place as a historical record.
+PRUNE_AFTER = timedelta(days=2)
+
+
+def _key(source_calendar_id, event_id):
+    return f"{source_calendar_id}::{event_id}"
+
+
+def _snapshot(event):
+    """The subset of fields whose change should propagate to the mirror."""
+    return {
+        'summary': event.get('summary'),
+        'start': event.get('start'),
+        'end': event.get('end'),
+        'location': event.get('location'),
+        'status': event.get('status'),
+    }
+
+
+def _mirror_body(event):
+    """The event body written onto the shared calendar."""
+    organizer_email = (event.get('organizer') or {}).get('email', 'someone')
+    return {
+        'summary': event.get('summary', '(no title)'),
+        'description': f"Mirrored by Calendar Bot from an event {organizer_email} invited you to.",
+        'start': event.get('start'),
+        'end': event.get('end'),
+        'location': event.get('location'),
+    }
+
+
+def _end_dt(event):
+    """Best-effort UTC end datetime for an event (handles all-day 'date')."""
+    val = (event.get('end') or {}).get('dateTime') or (event.get('end') or {}).get('date')
+    if not val:
+        return None
+    try:
+        if len(val) == 10:  # all-day 'YYYY-MM-DD'
+            return datetime.fromisoformat(val).replace(tzinfo=timezone.utc)
+        return datetime.fromisoformat(val.replace('Z', '+00:00'))
+    except ValueError:
+        return None
+
+
+def load_mirror_map():
+    if MIRROR_FILE.exists():
+        try:
+            return json.loads(MIRROR_FILE.read_text())
+        except json.JSONDecodeError:
+            logger.error("🪞 Mirror map file is corrupt; starting fresh.")
+    return {}
+
+
+def save_mirror_map(mirror_map):
+    MIRROR_FILE.parent.mkdir(parents=True, exist_ok=True)
+    MIRROR_FILE.write_text(json.dumps(mirror_map, indent=2))
+
+
+def is_self_organized(event):
+    """True if the source user organizes this event.
+
+    If organizer info is absent we return True so the bot keeps its existing
+    attendee-invite behavior rather than mirroring on incomplete data.
+    """
+    organizer = event.get('organizer')
+    if not organizer:
+        return True
+    return organizer.get('self', False)
+
+
+def ensure_mirror(service, source_calendar_id, event):
+    """Create or update the shared-calendar mirror for a non-organized event.
+
+    `service` is the source account's Calendar service (it has manage access to
+    the shared calendar). Returns True if a mirror exists/was written, False if
+    it was skipped (e.g. the shared calendar isn't writable).
+    """
+    mirror_map = load_mirror_map()
+    key = _key(source_calendar_id, event['id'])
+    snapshot = _snapshot(event)
+    record = mirror_map.get(key)
+
+    try:
+        if record and record.get('mirror_id'):
+            if record.get('snapshot') == snapshot:
+                return True  # already mirrored and unchanged
+            service.events().patch(
+                calendarId=SHARED_CALENDAR_ID, eventId=record['mirror_id'],
+                body=_mirror_body(event)
+            ).execute()
+            logger.info(f"🔁 Updated shared-calendar mirror for “{event.get('summary')}”.")
+        else:
+            created = service.events().insert(
+                calendarId=SHARED_CALENDAR_ID, body=_mirror_body(event)
+            ).execute()
+            record = {'mirror_id': created['id']}
+            logger.info(f"🪞 Mirrored “{event.get('summary')}” onto the shared calendar.")
+        record['snapshot'] = snapshot
+        mirror_map[key] = record
+        save_mirror_map(mirror_map)
+        return True
+    except HttpError as e:
+        if e.resp.status in (403, 404):
+            logger.warning(
+                f"⚠️ Cannot write to shared calendar '{SHARED_CALENDAR_ID}' (status {e.resp.status}). "
+                "Does the source account have manage access? Skipping mirror."
+            )
+            return False
+        raise
+
+
+def _delete_mirror(service, mirror_id):
+    if not mirror_id:
+        return
+    try:
+        service.events().delete(
+            calendarId=SHARED_CALENDAR_ID, eventId=mirror_id
+        ).execute()
+    except HttpError as e:
+        if e.resp.status not in (404, 410):  # already gone is fine
+            logger.error(f"Failed to delete shared-calendar mirror {mirror_id}: {e}")
+
+
+def reconcile_mirrors(build_service):
+    """Walk all tracked mirrors and propagate source moves/cancellations.
+
+    `build_service(calendar_id)` returns an authed Calendar service. Each
+    mirror is read from, and written to, using the service for its own source
+    calendar (which holds manage access to the shared calendar).
+    """
+    mirror_map = load_mirror_map()
+    if not mirror_map:
+        return
+
+    services = {}
+
+    def svc(cal):
+        if cal not in services:
+            services[cal] = build_service(cal)
+        return services[cal]
+
+    now = datetime.now(timezone.utc)
+    changed = False
+
+    for key, record in list(mirror_map.items()):
+        source_cal, source_eid = key.split('::', 1)
+
+        try:
+            source_service = svc(source_cal)
+        except Exception as e:
+            logger.error(f"🪞 Mirror reconcile: could not build service for {source_cal}: {e}")
+            continue
+
+        try:
+            source_event = source_service.events().get(
+                calendarId=source_cal, eventId=source_eid
+            ).execute()
+        except HttpError as e:
+            if e.resp.status in (404, 410):  # source deleted -> remove mirror
+                _delete_mirror(source_service, record.get('mirror_id'))
+                del mirror_map[key]
+                changed = True
+                logger.info("🗑️ Source event gone; removed its shared-calendar mirror.")
+            else:
+                logger.error(f"Mirror reconcile: failed to read source {key}: {e}")
+            continue
+
+        if source_event.get('status') == 'cancelled':  # source cancelled -> remove mirror
+            _delete_mirror(source_service, record.get('mirror_id'))
+            del mirror_map[key]
+            changed = True
+            logger.info("🗑️ Source event cancelled; removed its shared-calendar mirror.")
+            continue
+
+        end_dt = _end_dt(source_event)
+        if end_dt and end_dt < now - PRUNE_AFTER:  # stop tracking long-past events
+            del mirror_map[key]
+            changed = True
+            continue
+
+        snapshot = _snapshot(source_event)
+        if snapshot != record.get('snapshot'):  # source moved/edited -> patch mirror
+            try:
+                source_service.events().patch(
+                    calendarId=SHARED_CALENDAR_ID, eventId=record['mirror_id'],
+                    body=_mirror_body(source_event)
+                ).execute()
+                record['snapshot'] = snapshot
+                mirror_map[key] = record
+                changed = True
+                logger.info(f"🔁 Synced shared-calendar mirror for “{source_event.get('summary')}”.")
+            except HttpError as e:
+                logger.error(f"Mirror reconcile: failed to update mirror {key}: {e}")
+
+    if changed:
+        save_mirror_map(mirror_map)

--- a/utils/process_event.py
+++ b/utils/process_event.py
@@ -8,6 +8,7 @@ from googleapiclient.errors import HttpError
 
 from utils.logger import logger
 from utils.tenacity_utils import log_before_retry, log_and_email_on_final_failure
+from utils.mirror import is_self_organized, ensure_mirror
 
 INVITE_EMAIL = os.getenv('INVITE_EMAIL', 'joelandtaylor@gmail.com')
 PROCESSED_FILE_PATH_STR = os.getenv('PROCESSED_FILE', 'data/processed_events.json')
@@ -66,6 +67,14 @@ def handle_event(service, calendar_id: str, event_id: str, success_counter, invi
 
     if 'start' not in event or 'end' not in event:
         logger.warning(f"⚠️ Skipping event {event_id}: missing start or end.")
+        return
+
+    # If the user doesn't organize this event we can't add an attendee, so mirror
+    # it onto the shared calendar instead (and keep it synced via reconciliation).
+    if not is_self_organized(event):
+        if ensure_mirror(service, calendar_id, event):
+            success_counter.labels(calendar_id=calendar_id, event_type='mirrored').inc()
+            logger.info(f"🪞 Mirrored non-organized event “{summary}” ({event_id}) to shared calendar.")
         return
 
     attendees = event.get('attendees', [])


### PR DESCRIPTION
Closes #3 (the organizer-aware portion of the feature-gap review).

## Problem

Events the source user **organizes** get the shared calendar added as an attendee — and Google keeps attendees in sync natively (moves, cancellations). But you **cannot add an attendee to an event you don't organize**, so events the user was merely *invited* to never reached the shared kitchen calendar at all.

## Solution

Organizer-aware handling in `handle_event`:

- **You organize it** → unchanged: add the shared calendar as an attendee (self-syncing).
- **You don't** → create a standalone **mirror** event on the shared calendar and actively keep it in sync.

Both source accounts already have *manage* access to the shared calendar (verified live), so each source service writes and reconciles its own mirrors directly — no separate writer account or new token needed.

### New: `utils/mirror.py`
- Persistent `source event → mirror event` map (`data/mirrored_events.json`).
- `ensure_mirror()` — create or update a mirror; skips gracefully (warns) if the shared calendar isn't writable.
- `reconcile_mirrors()` — runs each poll: propagates source **moves** (patch the mirror), deletes the mirror when the source is **cancelled/deleted**, and prunes long-past entries.

### Wiring
- `handle_event` routes `default` events by `organizer.self`.
- `poll_calendar` calls `reconcile_mirrors()` each cycle (after new-event processing).

## Verification

- **Live end-to-end** against the real shared calendar: create → move (patch) → reconcile-delete. Confirmed the deleted mirror is a `cancelled` tombstone that does **not** appear in calendar listings.
- **Unit tests**: 18 passing (10 new in `tests/test_mirror.py` + an organizer-routing test). `flake8` clean.

## Notes / follow-ups (already logged as issues)

- Recurring non-organized events mirror per-instance (#6) and special event types (#5) still apply here — tracked separately.
- Mirroring only applies to events seen *after* this deploys; pre-existing invited events aren't backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)