### PR TITLE
Incremental syncToken sync — fix missed past/far-future events & handle updates/deletes (#3, #4)

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,9 +23,10 @@ from utils.logger import logger
 from utils.email_utils import send_error_email
 from utils.google_utils import build_calendar_service
 from utils.process_event import handle_event, load_processed, save_processed
-from utils.mirror import reconcile_mirrors
+from utils.mirror import reconcile_mirrors, remove_mirror
+from utils.sync import list_changes, load_sync_tokens, save_sync_tokens
 from utils.health import send_health_ping
-from utils.tenacity_utils import log_before_retry, log_and_email_on_final_failure
+from utils.tenacity_utils import log_before_retry
 
 # --- App Configuration Loading ---
 POLL_INTERVAL_MINUTES = int(os.getenv("POLL_INTERVAL_MINUTES", "5"))
@@ -99,27 +100,6 @@ def log_unhandled_exception(exc_type, exc_value, exc_traceback):
 
 sys.excepthook = log_unhandled_exception
 
-# --- Tenacity-decorated API Call ---
-@retry(
-    retry=retry_if_exception_type(HttpError),
-    wait=wait_exponential(multiplier=2, min=4, max=30),
-    stop=stop_after_attempt(4),
-    before_sleep=log_before_retry,
-    retry_error_callback=log_and_email_on_final_failure,
-    reraise=True
-)
-def fetch_recent_events(service, calendar_id):
-    #Fetches upcoming events from a given calendar, with retry logic.
-    now_utc = datetime.now(timezone.utc).isoformat()
-    events_result = service.events().list(
-        calendarId=calendar_id,
-        timeMin=now_utc,
-        maxResults=100,
-        singleEvents=True,
-        orderBy='startTime'
-    ).execute()
-    return events_result.get('items', [])
-
 def send_daily_health_report():
     """
     Sends a daily email summarizing the bot's operation.
@@ -191,42 +171,93 @@ def clean_processed_events_list():
         send_error_email("Calendar Bot - Memory Cleaning Failed", f"An error occurred: {e}")
 
 # --- Main Application Logic ---
+# Event types the bot clones once (rather than adding the shared calendar as an
+# attendee), so they need de-dup tracking in processed_ids.
+CLONE_EVENT_TYPES = ('birthday', 'fromGmail')
+
+
+def _process_change(service, calendar_id, event, is_full_sync):
+    """Apply a single synced event change. Returns True if processed_ids changed.
+
+    - Cancelled/deleted -> remove any shared-calendar mirror and forget the id.
+    - Clone types (birthday/fromGmail) -> clone once, guarded by processed_ids,
+      on both full and incremental syncs (so events beyond the old window aren't
+      missed).
+    - Invite/mirror types -> acted on only for incremental changes (a create or
+      an edit). On a full sync they're skipped to avoid mass-acting on the
+      calendar's existing events at startup/resync; idempotent re-adds happen
+      whenever they next change.
+    """
+    eid = event['id']
+
+    if event.get('status') == 'cancelled':
+        remove_mirror(service, calendar_id, eid)
+        if eid in processed_ids:
+            processed_ids.discard(eid)
+            return True
+        return False
+
+    event_type = event.get('eventType', 'default')
+
+    if event_type in CLONE_EVENT_TYPES:
+        if eid in processed_ids:
+            return False  # already cloned
+        if is_full_sync:
+            processed_ids.add(eid)  # seed pre-existing clones; no backfill cloning
+            return True
+        logger.info(f"✅ Processing new {event_type} event: {eid} from {calendar_id}")
+        handle_event(service, calendar_id, eid, EVENTS_PROCESSED_SUCCESS_TOTAL)
+        processed_ids.add(eid)
+        return True
+
+    if is_full_sync:
+        return False  # don't mass-act on pre-existing invite/mirror events
+
+    logger.info(f"✅ Processing changed event: {eid} from {calendar_id}")
+    handle_event(service, calendar_id, eid, EVENTS_PROCESSED_SUCCESS_TOTAL)
+    return False  # invite/mirror are idempotent; no processed_ids entry needed
+
+
 def poll_calendar():
-    #The core job that polls all source calendars and processes new events.
-    with POLL_DURATION_SECONDS.time(): # CORRECTED: Timer wraps all work
+    # Incrementally syncs all source calendars and processes changed events.
+    with POLL_DURATION_SECONDS.time():
         POLLS_INITIATED_TOTAL.inc()
         if UPTIME_KUMA_PUSH_URL: send_health_ping(f"{UPTIME_KUMA_PUSH_URL}")
         logger.info("⏱️ Running scheduled poll...")
 
+        sync_tokens = load_sync_tokens()
+
         for cal in SOURCE_CALENDARS:
-            logger.info(f"🔍 Polling calendar: {cal}")
+            logger.info(f"🔍 Syncing calendar: {cal}")
             try:
                 service = build_calendar_service(cal)
-                events = fetch_recent_events(service, cal)
-                logger.info(f"📆 Retrieved {len(events)} upcoming events from {cal}.")
-                events_processed_in_this_run = False
+                events, new_token, is_full_sync = list_changes(service, cal, sync_tokens.get(cal))
+                kind = 'events (full sync, seeding)' if is_full_sync else 'changed events'
+                logger.info(f"📆 {cal}: {len(events)} {kind}.")
+                processed_changed = False
                 for event in events:
                     eid = event.get('id')
-                    summary = event.get('summary', '(no title)')
-                    if not eid or eid in processed_ids:
+                    if not eid:
                         continue
-                    logger.info(f"✅ Processing new event: {eid} - {summary} from {cal}")
                     try:
-                        # CORRECTED: Pass metric objects into the function
-                        handle_event(service, cal, eid, EVENTS_PROCESSED_SUCCESS_TOTAL)
-                        processed_ids.add(eid)
-                        events_processed_in_this_run = True
+                        if _process_change(service, cal, event, is_full_sync):
+                            processed_changed = True
                     except HttpError:
                         logger.warning(f"Skipping event {eid} for {cal} after final processing attempt failed...")
                         EVENTS_PROCESSED_FAILURE_TOTAL.labels(calendar_id=cal, reason='api_http_error').inc()
                         processed_ids.add(eid)
-                        events_processed_in_this_run = True
+                        processed_changed = True
                         continue
                     except Exception as e_handle:
                         logger.error(f"❌ An unexpected error occurred while handling event {eid}: {e_handle}", exc_info=True)
                         EVENTS_PROCESSED_FAILURE_TOTAL.labels(calendar_id=cal, reason='unexpected_error').inc()
                         send_error_email("Calendar Bot - UNEXPECTED Event Error", f"Event ID: {eid}\nError: {e_handle}")
-                if events_processed_in_this_run:
+
+                # Persist the new sync token so the next poll is incremental.
+                if new_token:
+                    sync_tokens[cal] = new_token
+                    save_sync_tokens(sync_tokens)
+                if processed_changed:
                     save_processed(processed_ids)
                     PROCESSED_EVENT_IDS_COUNT.set(len(processed_ids))
                     logger.info(f"💾 Updated processed event list for {cal}.")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,10 +1,11 @@
 # ~/calendar_bot/tests/test_app.py
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 # Import the Flask app object from your main application file
-from app import app as flask_app
+import app as app_module
+from app import app as flask_app, _process_change
 
 @pytest.fixture()
 def app():
@@ -37,6 +38,69 @@ def test_metrics_endpoint(client):
     # Assert: Check for success and that a known metric is present in the response
     assert response.status_code == 200
     assert b'calendar_bot_polls_initiated_total' in response.data
+
+@pytest.fixture()
+def clean_processed_ids():
+    """Snapshot and restore app.processed_ids around a test."""
+    saved = set(app_module.processed_ids)
+    app_module.processed_ids.clear()
+    yield app_module.processed_ids
+    app_module.processed_ids.clear()
+    app_module.processed_ids.update(saved)
+
+
+def test_process_change_cancelled_removes_mirror(clean_processed_ids):
+    clean_processed_ids.add('evt1')
+    event = {'id': 'evt1', 'status': 'cancelled'}
+    with patch('app.remove_mirror') as mock_remove, patch('app.handle_event') as mock_handle:
+        changed = _process_change(MagicMock(), 'cal@x.com', event, is_full_sync=False)
+    mock_remove.assert_called_once()
+    mock_handle.assert_not_called()
+    assert 'evt1' not in clean_processed_ids
+    assert changed is True
+
+
+def test_process_change_clones_new_birthday_incremental(clean_processed_ids):
+    event = {'id': 'b1', 'eventType': 'birthday'}
+    with patch('app.handle_event') as mock_handle:
+        changed = _process_change(MagicMock(), 'cal@x.com', event, is_full_sync=False)
+    mock_handle.assert_called_once()
+    assert 'b1' in clean_processed_ids
+    assert changed is True
+
+
+def test_process_change_seeds_birthday_on_full_sync(clean_processed_ids):
+    # Full sync must not backfill-clone pre-existing birthdays, only seed them.
+    event = {'id': 'b1', 'eventType': 'birthday'}
+    with patch('app.handle_event') as mock_handle:
+        changed = _process_change(MagicMock(), 'cal@x.com', event, is_full_sync=True)
+    mock_handle.assert_not_called()
+    assert 'b1' in clean_processed_ids
+    assert changed is True
+
+
+def test_process_change_skips_already_cloned(clean_processed_ids):
+    clean_processed_ids.add('b1')
+    event = {'id': 'b1', 'eventType': 'birthday'}
+    with patch('app.handle_event') as mock_handle:
+        changed = _process_change(MagicMock(), 'cal@x.com', event, is_full_sync=False)
+    mock_handle.assert_not_called()
+    assert changed is False
+
+
+def test_process_change_skips_invite_on_full_sync(clean_processed_ids):
+    event = {'id': 'r1', 'eventType': 'default'}
+    with patch('app.handle_event') as mock_handle:
+        _process_change(MagicMock(), 'cal@x.com', event, is_full_sync=True)
+    mock_handle.assert_not_called()
+
+
+def test_process_change_acts_on_invite_incremental(clean_processed_ids):
+    event = {'id': 'r1', 'eventType': 'default'}
+    with patch('app.handle_event') as mock_handle:
+        _process_change(MagicMock(), 'cal@x.com', event, is_full_sync=False)
+    mock_handle.assert_called_once()
+
 
 def test_webhook_triggers_poll(client):
     """

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,72 @@
+# ~/calendar_bot/tests/test_sync.py
+from unittest.mock import MagicMock
+
+from googleapiclient.errors import HttpError
+
+from utils.sync import list_changes
+
+
+class _Resp:
+    def __init__(self, status):
+        self.status = status
+        self.reason = "error"
+
+
+def _http_error(status):
+    return HttpError(_Resp(status), b'{}')
+
+
+def _service_returning(pages):
+    """A mock Calendar service whose events().list().execute() yields `pages`
+    in order (each page a dict, or an exception to raise)."""
+    service = MagicMock()
+    service.events().list().execute.side_effect = pages
+    return service
+
+
+def test_full_sync_when_no_token():
+    service = _service_returning([{'items': [{'id': 'a'}, {'id': 'b'}], 'nextSyncToken': 'tok1'}])
+    events, token, is_full = list_changes(service, 'cal@x.com', None)
+    assert is_full is True
+    assert [e['id'] for e in events] == ['a', 'b']
+    assert token == 'tok1'
+    # Full sync must be bounded by timeMin, not a syncToken.
+    last_call = service.events().list.call_args.kwargs
+    assert 'timeMin' in last_call and 'syncToken' not in last_call
+
+
+def test_incremental_sync_with_token():
+    service = _service_returning([{'items': [{'id': 'c'}], 'nextSyncToken': 'tok2'}])
+    events, token, is_full = list_changes(service, 'cal@x.com', 'tok1')
+    assert is_full is False
+    assert [e['id'] for e in events] == ['c']
+    assert token == 'tok2'
+    assert service.events().list.call_args.kwargs.get('syncToken') == 'tok1'
+
+
+def test_expired_token_falls_back_to_full_sync():
+    # First (incremental) call 410s, then the full sync succeeds.
+    service = _service_returning([_http_error(410), {'items': [{'id': 'd'}], 'nextSyncToken': 'tok3'}])
+    events, token, is_full = list_changes(service, 'cal@x.com', 'stale')
+    assert is_full is True
+    assert [e['id'] for e in events] == ['d']
+    assert token == 'tok3'
+
+
+def test_pagination_collects_all_pages_and_final_token():
+    service = _service_returning([
+        {'items': [{'id': 'p1'}], 'nextPageToken': 'pg2'},
+        {'items': [{'id': 'p2'}], 'nextSyncToken': 'tokfinal'},
+    ])
+    events, token, is_full = list_changes(service, 'cal@x.com', None)
+    assert [e['id'] for e in events] == ['p1', 'p2']
+    assert token == 'tokfinal'
+
+
+def test_non_410_error_propagates():
+    service = _service_returning([_http_error(500)])
+    try:
+        list_changes(service, 'cal@x.com', 'tok')
+        assert False, "expected HttpError to propagate"
+    except HttpError as e:
+        assert e.resp.status == 500

--- a/utils/mirror.py
+++ b/utils/mirror.py
@@ -151,6 +151,19 @@ def _delete_mirror(service, mirror_id):
             logger.error(f"Failed to delete shared-calendar mirror {mirror_id}: {e}")
 
 
+def remove_mirror(service, source_calendar_id, event_id):
+    """Delete the shared-calendar mirror for a now cancelled/deleted source event."""
+    mirror_map = load_mirror_map()
+    key = _key(source_calendar_id, event_id)
+    record = mirror_map.get(key)
+    if not record:
+        return
+    _delete_mirror(service, record.get('mirror_id'))
+    del mirror_map[key]
+    save_mirror_map(mirror_map)
+    logger.info("🗑️ Removed shared-calendar mirror for a cancelled source event.")
+
+
 def reconcile_mirrors(build_service):
     """Walk all tracked mirrors and propagate source moves/cancellations.
 

--- a/utils/sync.py
+++ b/utils/sync.py
@@ -1,0 +1,86 @@
+# ~/calendar_bot/utils/sync.py
+"""
+Incremental calendar sync using Google Calendar syncTokens.
+
+Replaces the old "list the next 100 future events and dedupe by ID" poll with
+proper incremental sync. Each calendar keeps a syncToken, so subsequent syncs
+return only created / updated / deleted events — no 100-event cap, and updates
+and deletions are delivered (not just first-seen creates).
+
+The first sync for a calendar (or after a 410 token expiry) is a full sync
+bounded by timeMin=now; it yields a fresh syncToken for incremental syncs after.
+"""
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from googleapiclient.errors import HttpError
+
+from utils.logger import logger
+
+SYNC_TOKEN_FILE = Path(os.getenv('SYNC_TOKEN_FILE', 'data/sync_tokens.json'))
+_PAGE_SIZE = 2500  # max allowed; keeps the full initial sync to a few pages
+
+
+def load_sync_tokens():
+    if SYNC_TOKEN_FILE.exists():
+        try:
+            return json.loads(SYNC_TOKEN_FILE.read_text())
+        except json.JSONDecodeError:
+            logger.error("🔄 Sync token file is corrupt; starting fresh (full resync).")
+    return {}
+
+
+def save_sync_tokens(tokens):
+    SYNC_TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
+    SYNC_TOKEN_FILE.write_text(json.dumps(tokens, indent=2))
+
+
+def _list_all(service, base_params):
+    """Page through events().list, returning (events, next_sync_token).
+
+    nextSyncToken only appears on the final page, so we carry it forward.
+    """
+    events = []
+    sync_token = None
+    page_token = None
+    while True:
+        params = dict(base_params)
+        if page_token:
+            params['pageToken'] = page_token
+        resp = service.events().list(**params).execute()
+        events.extend(resp.get('items', []))
+        sync_token = resp.get('nextSyncToken') or sync_token
+        page_token = resp.get('nextPageToken')
+        if not page_token:
+            break
+    return events, sync_token
+
+
+def list_changes(service, calendar_id, stored_token):
+    """Return (events, new_sync_token, is_full_sync).
+
+    With a valid stored_token: an incremental sync returning only changed
+    events (including cancelled ones, since showDeleted=True). Without a token,
+    or on a 410 (expired token): a full sync bounded by timeMin=now.
+    """
+    common = dict(
+        calendarId=calendar_id,
+        singleEvents=True,
+        showDeleted=True,  # so deletions/cancellations are delivered incrementally
+        maxResults=_PAGE_SIZE,
+    )
+    if stored_token:
+        try:
+            events, token = _list_all(service, dict(common, syncToken=stored_token))
+            return events, token, False
+        except HttpError as e:
+            if e.resp.status == 410:  # token expired -> fall back to full resync
+                logger.warning(f"🔄 Sync token for {calendar_id} expired; doing a full resync.")
+            else:
+                raise
+
+    now = datetime.now(timezone.utc).isoformat()
+    events, token = _list_all(service, dict(common, timeMin=now))
+    return events, token, True


### PR DESCRIPTION
Closes #3 and #4.

## Problem

`poll_calendar` listed only the nearest 100 *future* events (`timeMin=now`, `maxResults=100`, no pagination) and deduped by ID. So it **missed events beyond the 100-event window** and **never saw updates or deletions** — once an ID was processed it was never revisited (#3, #4). On these calendars the window is huge: a full expanded list is **~6,100** events (joeltimm) and **~7,300** (tsouthworth) because `singleEvents=True` expands recurring series.

## Solution — Google Calendar incremental sync

**`utils/sync.py`** — per-calendar `syncToken` persistence (`data/sync_tokens.json`) and `list_changes()`:
- No token (first run) → full sync bounded by `timeMin=now`, paginated, returns a `nextSyncToken`.
- With token → incremental sync returning **only changed events**, including cancellations (`showDeleted=True`).
- `410` (expired token) → automatic full resync.

**`app.py`** — `poll_calendar` syncs via `list_changes` and routes each change through `_process_change()`:
| Change | Action |
|---|---|
| cancelled / deleted | remove the shared-calendar mirror, forget the id |
| `birthday` / `fromGmail` | clone once (guarded by `processed_ids`) |
| invite / mirror types | acted on for **incremental** changes only |

The invite/mirror incremental path is what delivers **#4**: a manually-removed shared invite gets re-added on the next edit, and mirrors update/delete with their source.

**Seed-without-act on full syncs.** A first run or 410 resync returns thousands of pre-existing events; acting on them would mass-invite/clone. So full syncs only *seed* state (record ids + token) and don't act. Going forward, incremental changes are acted on. This is consistent with the no-backfill behavior noted previously.

**`utils/mirror.py`** — `remove_mirror()` for cancellation cleanup. Dropped the now-unused `fetch_recent_events`.

## Effects
- No more 100-event blind spot; far-future events are tracked.
- Updates and deletions are handled (re-add removed invites; delete mirrors on cancel).
- Efficiency: incremental polls fetch ~0 events instead of 100 every cycle.

## Verification
- 29 unit tests pass (new `test_sync.py` + `_process_change` routing tests); flake8 clean.
- Live: full + incremental sync confirmed against both real calendars (7309 / 6100 full → 0 incremental, valid tokens).

## Known limitations (smaller follow-ups)
- Deep-past events created with a start before `timeMin` aren't backfilled (edge case).
- Clone (#6) per-instance behavior and special event types (#5) are unchanged and still tracked separately. A changed birthday won't re-sync its clone (clone-update is out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)