### PR TITLE
Skip special-type and cancelled/declined events (#5, #7)

### DIFF
--- a/tests/test_process_event.py
+++ b/tests/test_process_event.py
@@ -114,6 +114,44 @@ def not_organized_event():
     }
 
 
+def test_skips_special_event_type(mock_google_service):
+    ooo = {
+        'id': 'ooo1', 'summary': 'Out of office', 'eventType': 'outOfOffice',
+        'start': {'dateTime': '2030-09-05T10:00:00Z'}, 'end': {'dateTime': '2030-09-05T11:00:00Z'},
+    }
+    mock_google_service.events().get.return_value.execute.return_value = ooo
+    handle_event(service=mock_google_service, calendar_id='primary', event_id='ooo1', success_counter=MagicMock())
+    mock_google_service.events().patch.assert_not_called()
+    mock_google_service.events().insert.assert_not_called()
+
+
+def test_skips_cancelled_event(mock_google_service):
+    cancelled = {
+        'id': 'c1', 'summary': 'Gone', 'eventType': 'default', 'status': 'cancelled',
+        'start': {'dateTime': '2030-09-05T10:00:00Z'}, 'end': {'dateTime': '2030-09-05T11:00:00Z'},
+    }
+    mock_google_service.events().get.return_value.execute.return_value = cancelled
+    handle_event(service=mock_google_service, calendar_id='primary', event_id='c1', success_counter=MagicMock())
+    mock_google_service.events().patch.assert_not_called()
+    mock_google_service.events().insert.assert_not_called()
+
+
+def test_skips_declined_event_and_drops_mirror(mock_google_service):
+    declined = {
+        'id': 'd1', 'summary': 'Declined Mtg', 'eventType': 'default',
+        'organizer': {'email': 'boss@example.com', 'self': False},
+        'start': {'dateTime': '2030-09-05T10:00:00Z'}, 'end': {'dateTime': '2030-09-05T11:00:00Z'},
+        'attendees': [{'email': 'user@example.com', 'self': True, 'responseStatus': 'declined'}],
+    }
+    mock_google_service.events().get.return_value.execute.return_value = declined
+    with patch('utils.process_event.remove_mirror') as mock_remove, \
+         patch('utils.process_event.ensure_mirror') as mock_ensure:
+        handle_event(service=mock_google_service, calendar_id='primary', event_id='d1', success_counter=MagicMock())
+    mock_ensure.assert_not_called()
+    mock_remove.assert_called_once()
+    mock_google_service.events().patch.assert_not_called()
+
+
 def test_mirrors_non_organized_event(mock_google_service, not_organized_event):
     mock_google_service.events().get.return_value.execute.return_value = not_organized_event
 

--- a/utils/process_event.py
+++ b/utils/process_event.py
@@ -8,11 +8,23 @@ from googleapiclient.errors import HttpError
 
 from utils.logger import logger
 from utils.tenacity_utils import log_before_retry, log_and_email_on_final_failure
-from utils.mirror import is_self_organized, ensure_mirror
+from utils.mirror import is_self_organized, ensure_mirror, remove_mirror
 
 INVITE_EMAIL = os.getenv('INVITE_EMAIL', 'joelandtaylor@gmail.com')
 PROCESSED_FILE_PATH_STR = os.getenv('PROCESSED_FILE', 'data/processed_events.json')
 PROCESSED_FILE = Path(PROCESSED_FILE_PATH_STR)
+
+# Event types that cannot carry attendees and aren't meaningful to clone/mirror;
+# attempting to add an attendee to these returns an API error, so we skip them.
+SKIP_EVENT_TYPES = ('outOfOffice', 'focusTime', 'workingLocation')
+
+
+def _user_declined(event):
+    """True if the calendar owner's own attendee entry is 'declined'."""
+    for attendee in event.get('attendees', []):
+        if attendee.get('self') and attendee.get('responseStatus') == 'declined':
+            return True
+    return False
 
 def load_processed():
     if PROCESSED_FILE.exists():
@@ -38,6 +50,20 @@ def handle_event(service, calendar_id: str, event_id: str, success_counter, invi
     event = service.events().get(calendarId=calendar_id, eventId=event_id).execute()
     summary = event.get('summary', '(no title)')
     event_type = event.get("eventType", "default") # Use "default" if type is not specified
+
+    # (#5) Skip event types that can't have attendees / aren't meaningful to mirror.
+    if event_type in SKIP_EVENT_TYPES:
+        logger.info(f"⏭️ Skipping '{event_type}' event “{summary}” ({event_id}); not actionable.")
+        return
+
+    # (#7) Skip cancelled or declined events; drop any stale mirror for a declined one.
+    if event.get('status') == 'cancelled':
+        logger.info(f"⏭️ Skipping cancelled event “{summary}” ({event_id}).")
+        return
+    if _user_declined(event):
+        logger.info(f"⏭️ Skipping declined event “{summary}” ({event_id}).")
+        remove_mirror(service, calendar_id, event_id)
+        return
 
     if event_type == "birthday":
         logger.info(f"🎂 Detected 'birthday' event: “{summary}”. Cloning to shared calendar.")


### PR DESCRIPTION
Closes #5. Closes #7.

## Problem
`handle_event` added the shared calendar to every non-clone event. That:
- **Errored** on event types that can't have attendees (`outOfOffice`, `focusTime`, `workingLocation`) — a guaranteed `HttpError`, logged and emailed each time (#5).
- **Acted on declined/cancelled events** — no check on `status` or the owner's own `responseStatus`, so the shared calendar got dragged into things you declined (#7).

## Change
Early skips in `handle_event`, before any clone/mirror/invite action:
- (#5) Skip `eventType` in `outOfOffice`, `focusTime`, `workingLocation`.
- (#7) Skip `status == 'cancelled'`; skip when the owner's own attendee `responseStatus == 'declined'`. For a declined event, also `remove_mirror(...)` so a previously-mirrored event that you later decline doesn't linger on the kitchen calendar.

## Verification
- 32 unit tests pass (3 new: special-type, cancelled, declined-drops-mirror); flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)