### PR TITLE
Series-level recurring handling + clone-orphan cleanup (#6, #4)

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,8 @@ from utils.logger import logger
 from utils.email_utils import send_error_email
 from utils.google_utils import build_calendar_service
 from utils.process_event import handle_event, load_processed, save_processed
-from utils.mirror import reconcile_mirrors, remove_mirror
+from utils.mirror import reconcile_mirrors, remove_mirror, apply_instance_exception
+from utils.clones import remove_clone
 from utils.sync import list_changes, load_sync_tokens, save_sync_tokens
 from utils.health import send_health_ping
 from utils.tenacity_utils import log_before_retry
@@ -190,8 +191,18 @@ def _process_change(service, calendar_id, event, is_full_sync):
     """
     eid = event['id']
 
+    # A single-occurrence exception of a recurring series (one instance edited or
+    # cancelled): reflect it onto the mirror's matching occurrence rather than
+    # treating it as a standalone event. On a full sync no mirrors exist yet, so
+    # this is a no-op there.
+    if event.get('recurringEventId'):
+        if not is_full_sync:
+            apply_instance_exception(service, calendar_id, event)
+        return False
+
     if event.get('status') == 'cancelled':
         remove_mirror(service, calendar_id, eid)
+        remove_clone(service, calendar_id, eid)
         if eid in processed_ids:
             processed_ids.discard(eid)
             return True
@@ -234,6 +245,9 @@ def poll_calendar():
                 events, new_token, is_full_sync = list_changes(service, cal, sync_tokens.get(cal))
                 kind = 'events (full sync, seeding)' if is_full_sync else 'changed events'
                 logger.info(f"📆 {cal}: {len(events)} {kind}.")
+                # Process masters/singles before instance-exceptions so a series'
+                # mirror exists before we adjust one of its occurrences.
+                events.sort(key=lambda e: 1 if e.get('recurringEventId') else 0)
                 processed_changed = False
                 for event in events:
                     eid = event.get('id')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -49,15 +49,34 @@ def clean_processed_ids():
     app_module.processed_ids.update(saved)
 
 
-def test_process_change_cancelled_removes_mirror(clean_processed_ids):
+def test_process_change_cancelled_removes_mirror_and_clone(clean_processed_ids):
     clean_processed_ids.add('evt1')
     event = {'id': 'evt1', 'status': 'cancelled'}
-    with patch('app.remove_mirror') as mock_remove, patch('app.handle_event') as mock_handle:
+    with patch('app.remove_mirror') as mock_remove, patch('app.remove_clone') as mock_clone, \
+         patch('app.handle_event') as mock_handle:
         changed = _process_change(MagicMock(), 'cal@x.com', event, is_full_sync=False)
     mock_remove.assert_called_once()
+    mock_clone.assert_called_once()
     mock_handle.assert_not_called()
     assert 'evt1' not in clean_processed_ids
     assert changed is True
+
+
+def test_process_change_routes_exception_to_mirror(clean_processed_ids):
+    event = {'id': 'm1_i', 'recurringEventId': 'm1', 'status': 'cancelled',
+             'originalStartTime': {'dateTime': '2030-01-01T09:00:00Z'}}
+    with patch('app.apply_instance_exception') as mock_exc, patch('app.handle_event') as mock_handle:
+        _process_change(MagicMock(), 'cal@x.com', event, is_full_sync=False)
+    mock_exc.assert_called_once()
+    mock_handle.assert_not_called()
+
+
+def test_process_change_skips_exception_on_full_sync(clean_processed_ids):
+    event = {'id': 'm1_i', 'recurringEventId': 'm1',
+             'originalStartTime': {'dateTime': '2030-01-01T09:00:00Z'}}
+    with patch('app.apply_instance_exception') as mock_exc:
+        _process_change(MagicMock(), 'cal@x.com', event, is_full_sync=True)
+    mock_exc.assert_not_called()
 
 
 def test_process_change_clones_new_birthday_incremental(clean_processed_ids):

--- a/tests/test_clones.py
+++ b/tests/test_clones.py
@@ -1,0 +1,34 @@
+# ~/calendar_bot/tests/test_clones.py
+from unittest.mock import MagicMock, patch
+
+from utils import clones
+from utils.clones import record_clone, remove_clone
+
+
+def test_record_clone_persists_mapping():
+    with patch.object(clones, 'load_clone_map', return_value={}), \
+         patch.object(clones, 'save_clone_map') as save:
+        record_clone('cal@x.com', 'src1', 'clone1')
+    saved = save.call_args.args[0]
+    assert saved['cal@x.com::src1']['clone_id'] == 'clone1'
+
+
+def test_remove_clone_deletes_and_forgets():
+    service = MagicMock()
+    cmap = {'cal@x.com::src1': {'clone_id': 'clone1'}}
+    with patch.object(clones, 'load_clone_map', return_value=cmap), \
+         patch.object(clones, 'save_clone_map') as save:
+        remove_clone(service, 'cal@x.com', 'src1')
+    del_kwargs = service.events().delete.call_args.kwargs
+    assert del_kwargs['calendarId'] == 'cal@x.com'
+    assert del_kwargs['eventId'] == 'clone1'
+    assert save.call_args.args[0] == {}  # mapping entry removed
+
+
+def test_remove_clone_noop_when_untracked():
+    service = MagicMock()
+    with patch.object(clones, 'load_clone_map', return_value={}), \
+         patch.object(clones, 'save_clone_map') as save:
+        remove_clone(service, 'cal@x.com', 'src1')
+    service.events().delete.assert_not_called()
+    save.assert_not_called()

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock, patch
 from googleapiclient.errors import HttpError
 
 from utils import mirror
-from utils.mirror import ensure_mirror, reconcile_mirrors, is_self_organized, _snapshot, SHARED_CALENDAR_ID
+from utils.mirror import (
+    ensure_mirror, reconcile_mirrors, is_self_organized, _snapshot, _mirror_body,
+    apply_instance_exception, SHARED_CALENDAR_ID,
+)
 
 
 class _Resp:
@@ -122,3 +125,50 @@ def test_reconcile_patches_mirror_when_source_moved(event):
          patch.object(mirror, 'save_mirror_map'):
         reconcile_mirrors(lambda cal: service)
     service.events().patch.assert_called_once()
+
+
+# --- recurrence + instance exceptions ---
+
+def test_mirror_body_copies_recurrence():
+    ev = {'summary': 'Weekly', 'start': {}, 'end': {}, 'recurrence': ['RRULE:FREQ=WEEKLY']}
+    assert _mirror_body(ev)['recurrence'] == ['RRULE:FREQ=WEEKLY']
+
+
+def _exception(status=None):
+    e = {
+        'id': 'master1_20300101', 'recurringEventId': 'master1',
+        'originalStartTime': {'dateTime': '2030-01-01T09:00:00Z'},
+        'start': {'dateTime': '2030-01-01T15:00:00Z'}, 'end': {'dateTime': '2030-01-01T16:00:00Z'},
+        'summary': 'Moved occurrence',
+    }
+    if status:
+        e['status'] = status
+    return e
+
+
+def test_apply_instance_exception_cancels_mirror_instance():
+    service = MagicMock()
+    service.events().instances().execute.return_value = {'items': [{'id': 'mir1_i', 'status': 'confirmed'}]}
+    mm = {'cal@x.com::master1': {'mirror_id': 'mir1', 'snapshot': {}}}
+    with patch.object(mirror, 'load_mirror_map', return_value=mm):
+        apply_instance_exception(service, 'cal@x.com', _exception(status='cancelled'))
+    service.events().delete.assert_called_once()
+    service.events().patch.assert_not_called()
+
+
+def test_apply_instance_exception_moves_mirror_instance():
+    service = MagicMock()
+    service.events().instances().execute.return_value = {'items': [{'id': 'mir1_i', 'status': 'confirmed'}]}
+    mm = {'cal@x.com::master1': {'mirror_id': 'mir1', 'snapshot': {}}}
+    with patch.object(mirror, 'load_mirror_map', return_value=mm):
+        apply_instance_exception(service, 'cal@x.com', _exception())
+    service.events().patch.assert_called_once()
+    service.events().delete.assert_not_called()
+
+
+def test_apply_instance_exception_noop_when_series_not_mirrored():
+    service = MagicMock()
+    with patch.object(mirror, 'load_mirror_map', return_value={}):
+        apply_instance_exception(service, 'cal@x.com', _exception(status='cancelled'))
+    service.events().delete.assert_not_called()
+    service.events().patch.assert_not_called()

--- a/tests/test_process_event.py
+++ b/tests/test_process_event.py
@@ -89,14 +89,15 @@ def test_skips_already_invited_event(mock_google_service, already_invited_event)
 
 def test_clones_birthday_event(mock_google_service, birthday_event):
     mock_google_service.events().get.return_value.execute.return_value = birthday_event
-    
-    handle_event(
-        service=mock_google_service, 
-        calendar_id='primary', 
-        event_id='birthday_event_789',
-        success_counter=MagicMock()
-    )
-    
+
+    with patch('utils.process_event.record_clone'):
+        handle_event(
+            service=mock_google_service,
+            calendar_id='primary',
+            event_id='birthday_event_789',
+            success_counter=MagicMock()
+        )
+
     mock_google_service.events().insert.assert_called_once()
     mock_google_service.events().patch.assert_not_called()
 

--- a/utils/clones.py
+++ b/utils/clones.py
@@ -1,0 +1,70 @@
+# ~/calendar_bot/utils/clones.py
+"""
+Track events the bot clones so they can be cleaned up when their source is gone.
+
+`birthday` events can't carry attendees, so the bot clones them onto the source
+calendar (with the shared calendar invited). Those clones are independent events
+with no link back to the original, so if the original birthday is removed the
+clone would be orphaned. We record source -> clone here and delete the clone when
+the source is cancelled/deleted.
+
+(fromGmail events are intentionally deleted by the bot after duplication, so they
+are deliberately not tracked here — tracking them would delete the duplicate.)
+"""
+import json
+import os
+from pathlib import Path
+
+from googleapiclient.errors import HttpError
+
+from utils.logger import logger
+
+CLONE_FILE = Path(os.getenv('CLONE_FILE', 'data/cloned_events.json'))
+
+
+def _key(source_calendar_id, event_id):
+    return f"{source_calendar_id}::{event_id}"
+
+
+def load_clone_map():
+    if CLONE_FILE.exists():
+        try:
+            return json.loads(CLONE_FILE.read_text())
+        except json.JSONDecodeError:
+            logger.error("🧬 Clone map file is corrupt; starting fresh.")
+    return {}
+
+
+def save_clone_map(clone_map):
+    CLONE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CLONE_FILE.write_text(json.dumps(clone_map, indent=2))
+
+
+def record_clone(source_calendar_id, source_event_id, clone_id):
+    """Remember that `source_event_id` was cloned into `clone_id`."""
+    clone_map = load_clone_map()
+    clone_map[_key(source_calendar_id, source_event_id)] = {'clone_id': clone_id}
+    save_clone_map(clone_map)
+
+
+def remove_clone(service, source_calendar_id, source_event_id):
+    """Delete the clone for a now cancelled/deleted source event (no-op if none).
+
+    The clone lives on the source calendar, so it is deleted with the source
+    account's own service.
+    """
+    clone_map = load_clone_map()
+    key = _key(source_calendar_id, source_event_id)
+    record = clone_map.get(key)
+    if not record:
+        return
+    clone_id = record.get('clone_id')
+    if clone_id:
+        try:
+            service.events().delete(calendarId=source_calendar_id, eventId=clone_id).execute()
+            logger.info("🗑️ Deleted an orphaned birthday clone whose source was removed.")
+        except HttpError as e:
+            if e.resp.status not in (404, 410):  # already gone is fine
+                logger.error(f"Failed to delete clone {clone_id}: {e}")
+    del clone_map[key]
+    save_clone_map(clone_map)

--- a/utils/mirror.py
+++ b/utils/mirror.py
@@ -44,19 +44,41 @@ def _snapshot(event):
         'end': event.get('end'),
         'location': event.get('location'),
         'status': event.get('status'),
+        'recurrence': event.get('recurrence'),  # so recurrence edits re-sync the mirror
     }
 
 
 def _mirror_body(event):
-    """The event body written onto the shared calendar."""
+    """The event body written onto the shared calendar.
+
+    For a recurring master we copy its recurrence rule so the mirror is itself a
+    recurring event (rather than N separate mirror events).
+    """
     organizer_email = (event.get('organizer') or {}).get('email', 'someone')
-    return {
+    start = dict(event.get('start') or {})
+    end = dict(event.get('end') or {})
+    body = {
         'summary': event.get('summary', '(no title)'),
         'description': f"Mirrored by Calendar Bot from an event {organizer_email} invited you to.",
-        'start': event.get('start'),
-        'end': event.get('end'),
+        'start': start,
+        'end': end,
         'location': event.get('location'),
     }
+    if event.get('recurrence'):
+        body['recurrence'] = event['recurrence']
+        # Recurring events with a dateTime require a time zone; default to UTC if absent.
+        for slot in (start, end):
+            if slot.get('dateTime') and not slot.get('timeZone'):
+                slot['timeZone'] = 'UTC'
+    return body
+
+
+def _ensure_timezone(slot):
+    """Recurring-event dateTimes need a timeZone; default to UTC if missing."""
+    if slot and slot.get('dateTime') and not slot.get('timeZone'):
+        slot = dict(slot)
+        slot['timeZone'] = 'UTC'
+    return slot
 
 
 def _end_dt(event):
@@ -162,6 +184,60 @@ def remove_mirror(service, source_calendar_id, event_id):
     del mirror_map[key]
     save_mirror_map(mirror_map)
     logger.info("🗑️ Removed shared-calendar mirror for a cancelled source event.")
+
+
+def apply_instance_exception(service, source_calendar_id, exception_event):
+    """Reflect a single-occurrence change of a recurring source series onto its
+    mirror: cancel or move the matching instance of the mirror event.
+
+    No-op if the series isn't mirrored (e.g. it's self-organized) or the matching
+    mirror instance can't be located.
+    """
+    master_id = exception_event.get('recurringEventId')
+    original_start = exception_event.get('originalStartTime') or {}
+    start_val = original_start.get('dateTime') or original_start.get('date')
+    if not master_id or not start_val:
+        return
+
+    record = load_mirror_map().get(_key(source_calendar_id, master_id))
+    if not record or not record.get('mirror_id'):
+        return  # series not mirrored (likely self-organized) -> nothing to do
+    mirror_id = record['mirror_id']
+
+    try:
+        resp = service.events().instances(
+            calendarId=SHARED_CALENDAR_ID, eventId=mirror_id,
+            originalStart=start_val, showDeleted=True,
+        ).execute()
+    except HttpError as e:
+        logger.error(f"Mirror exception: could not list mirror instance for {mirror_id} @ {start_val}: {e}")
+        return
+
+    instances = resp.get('items', [])
+    if not instances:
+        return  # no matching mirror instance to act on
+    instance = instances[0]
+
+    try:
+        if exception_event.get('status') == 'cancelled':
+            if instance.get('status') != 'cancelled':
+                service.events().delete(
+                    calendarId=SHARED_CALENDAR_ID, eventId=instance['id']
+                ).execute()
+                logger.info("🗑️ Cancelled a single mirror occurrence to match the source.")
+        else:
+            service.events().patch(
+                calendarId=SHARED_CALENDAR_ID, eventId=instance['id'],
+                body={
+                    'summary': exception_event.get('summary', instance.get('summary')),
+                    'start': _ensure_timezone(exception_event.get('start')),
+                    'end': _ensure_timezone(exception_event.get('end')),
+                    'location': exception_event.get('location'),
+                },
+            ).execute()
+            logger.info("🔁 Moved a single mirror occurrence to match the source.")
+    except HttpError as e:
+        logger.error(f"Mirror exception: failed to apply to mirror instance {instance.get('id')}: {e}")
 
 
 def reconcile_mirrors(build_service):

--- a/utils/process_event.py
+++ b/utils/process_event.py
@@ -9,6 +9,7 @@ from googleapiclient.errors import HttpError
 from utils.logger import logger
 from utils.tenacity_utils import log_before_retry, log_and_email_on_final_failure
 from utils.mirror import is_self_organized, ensure_mirror, remove_mirror
+from utils.clones import record_clone
 
 INVITE_EMAIL = os.getenv('INVITE_EMAIL', 'joelandtaylor@gmail.com')
 PROCESSED_FILE_PATH_STR = os.getenv('PROCESSED_FILE', 'data/processed_events.json')
@@ -73,6 +74,7 @@ def handle_event(service, calendar_id: str, event_id: str, success_counter, invi
             "attendees":   [{"email": invite_email}], "transparency": "transparent",
         }
         inserted = service.events().insert(calendarId=calendar_id, body=new_birthday_event, sendUpdates="all").execute()
+        record_clone(calendar_id, event_id, inserted['id'])  # so the clone is cleaned up if the source is removed
         success_counter.labels(calendar_id=calendar_id, event_type='birthday_clone').inc()
         logger.info(f"✅ Cloned birthday as new event ID {inserted['id']} for “{inserted.get('summary')}”")
         return

--- a/utils/sync.py
+++ b/utils/sync.py
@@ -21,12 +21,19 @@ from utils.logger import logger
 
 SYNC_TOKEN_FILE = Path(os.getenv('SYNC_TOKEN_FILE', 'data/sync_tokens.json'))
 _PAGE_SIZE = 2500  # max allowed; keeps the full initial sync to a few pages
+# Bump whenever the list() query parameters change: a syncToken is only valid
+# for the exact query that produced it, so a change must force a full resync.
+# v2: switched from singleEvents=True (per-instance) to series-level sync.
+_SYNC_VERSION = 2
 
 
 def load_sync_tokens():
     if SYNC_TOKEN_FILE.exists():
         try:
-            return json.loads(SYNC_TOKEN_FILE.read_text())
+            data = json.loads(SYNC_TOKEN_FILE.read_text())
+            if isinstance(data, dict) and data.get('_version') == _SYNC_VERSION:
+                return data.get('tokens', {})
+            logger.info("🔄 Sync token version changed; ignoring old tokens (one full resync).")
         except json.JSONDecodeError:
             logger.error("🔄 Sync token file is corrupt; starting fresh (full resync).")
     return {}
@@ -34,7 +41,7 @@ def load_sync_tokens():
 
 def save_sync_tokens(tokens):
     SYNC_TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
-    SYNC_TOKEN_FILE.write_text(json.dumps(tokens, indent=2))
+    SYNC_TOKEN_FILE.write_text(json.dumps({'_version': _SYNC_VERSION, 'tokens': tokens}, indent=2))
 
 
 def _list_all(service, base_params):
@@ -67,8 +74,8 @@ def list_changes(service, calendar_id, stored_token):
     """
     common = dict(
         calendarId=calendar_id,
-        singleEvents=True,
-        showDeleted=True,  # so deletions/cancellations are delivered incrementally
+        singleEvents=False,  # series-level: recurring events as masters, not per-instance
+        showDeleted=True,    # so deletions/cancellations are delivered incrementally
         maxResults=_PAGE_SIZE,
     )
     if stored_token:


### PR DESCRIPTION
Closes #6. Closes #4.

## #6 — recurring events per-instance → per-series
The sync used `singleEvents=True`, exploding recurring series into **6,082 / 7,309** per-instance events per calendar. The bot invited/mirrored the shared calendar to *every* instance and bloated `processed_events.json`.

Switch to **series-level sync** (`singleEvents=False`) → ~120-150 items per calendar:
- **sync.py:** `singleEvents=False`; sync tokens are **versioned**, so this query change forces one clean full resync on deploy (old tokens ignored).
- **Invite path:** the shared calendar is added to the series **master** once; Google propagates to all instances. Masters/singles are processed before instance-exceptions within a batch.
- **Mirror path:** non-organized recurring series are mirrored as a **single recurring event** (copying the RRULE, with a UTC `timeZone` fallback). Single occurrences cancelled or moved at the source are reflected onto the matching mirror instance via the `instances()` API (`apply_instance_exception`).

## #4 — clone-orphan cleanup
Birthday clones are now tracked in `data/cloned_events.json` and **deleted when their source is cancelled/removed** (`clones.py`). `fromGmail` is intentionally **not** tracked — its original is deleted by design, so tracking would delete the duplicate.

## Verification
- **Live against the real shared calendar:** recurring mirror create (5 instances), single-occurrence **cancel** (→4 active), single-occurrence **move** (09:00Z→14:00Z) — all confirmed, then cleaned up. (Live testing also caught a real bug: recurring events require a `timeZone` on `dateTime` — fixed with a UTC fallback.)
- 41 unit tests pass (new `test_clones.py` + recurrence/exception/clone routing tests); flake8 clean.

## Notes
- Deploy does one full resync (seed-without-act) under the new query; behavior is unchanged for existing events (no backfill), new/changed events handled going forward.
- `processed_events.json` will shrink over time as old per-instance IDs age out; new IDs are series-level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)